### PR TITLE
feat: add AI Agent Skills and Agent Role Add-on documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:vue": "pnpm --filter @stateref/connect-vue build",
     "build:svelte": "pnpm --filter @stateref/connect-svelte build",
     "build:solid": "pnpm --filter @stateref/connect-solid build",
-    "build": "pnpm build:core && pnpm build:!core",
+    "build": "pnpm build:core && pnpm build:!core && node scripts/copy-skills.mjs",
 
     "test": "pnpm -r test",
     "test:core": "pnpm --filter state-ref test",

--- a/packages/state-ref/package.json
+++ b/packages/state-ref/package.json
@@ -24,7 +24,9 @@
   "types": "./dist/index.d.ts",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "dist/skills",
+    "dist/ai-addons"
   ],
   "author": "superlucky84",
   "repository": {

--- a/scripts/copy-skills.mjs
+++ b/scripts/copy-skills.mjs
@@ -1,0 +1,70 @@
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'fs';
+import { dirname, extname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = dirname(__dirname);
+
+const skillsSourceRoot = `${projectRoot}/skills`;
+const skillsDistRoot = `${projectRoot}/packages/state-ref/dist/skills`;
+const aiAddonsRoot = `${projectRoot}/packages/state-ref/dist/ai-addons`;
+
+// Reset dist/skills and create dist/ai-addons directories
+rmSync(skillsDistRoot, { recursive: true, force: true });
+mkdirSync(skillsDistRoot, { recursive: true });
+mkdirSync(aiAddonsRoot, { recursive: true });
+
+// Read version from state-ref package.json
+const packageJson = JSON.parse(
+  readFileSync(`${projectRoot}/packages/state-ref/package.json`, 'utf8')
+);
+const version = packageJson.version ?? '0.0.0';
+
+const copySkillsTree = (sourceDir, targetDir) => {
+  mkdirSync(targetDir, { recursive: true });
+  const entries = readdirSync(sourceDir, { withFileTypes: true });
+
+  entries.forEach((entry) => {
+    const sourcePath = join(sourceDir, entry.name);
+    const targetPath = join(targetDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copySkillsTree(sourcePath, targetPath);
+      return;
+    }
+
+    if (!entry.isFile()) {
+      return;
+    }
+
+    if (extname(entry.name) === '.md') {
+      const content = readFileSync(sourcePath, 'utf8');
+      const withVersion = content.replace(/{{version}}/g, version);
+      writeFileSync(targetPath, withVersion);
+      return;
+    }
+
+    copyFileSync(sourcePath, targetPath);
+  });
+};
+
+// Copy skills directory to dist/skills with version injected in markdown files
+copySkillsTree(skillsSourceRoot, skillsDistRoot);
+
+console.log(`✓ Copied skills/ to packages/state-ref/dist/skills/ (version: ${version})`);
+
+// Process state-ref-agent-addon.md (agent role add-on)
+const addonSource = readFileSync(`${projectRoot}/state-ref-agent-addon.md`, 'utf8');
+const addonWithVersion = addonSource.replace(/^(# state-ref Agent Role Add-on)/m, `$1\n\nDocument Version: ${version}`);
+
+// Copy state-ref-agent-addon.md to dist/ai-addons/ with version injected
+writeFileSync(`${aiAddonsRoot}/state-ref-agent-addon.md`, addonWithVersion);
+
+console.log(`✓ Copied state-ref-agent-addon.md to packages/state-ref/dist/ai-addons/ (version: ${version})`);

--- a/skills/state-ref/SKILL.md
+++ b/skills/state-ref/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: state-ref
+description: Use when working in projects that use state-ref; follow proxy-based reactivity and lens pattern guidelines.
+metadata:
+  short-description: state-ref workflow
+  version: {{version}}
+---
+
+# state-ref AI Agent Skills
+
+Document Version: {{version}}
+
+Additional materials (optional):
+- constraints/ (rules, mistakes, troubleshooting)
+- reference/ (watch, store creation, framework connectors)
+- examples/ (quick examples)
+
+## Activation Condition (Read First)
+
+These guidelines apply **only when `state-ref` is installed** in the current project.
+
+Before following this document:
+- Check `package.json` for `state-ref` in dependencies/devDependencies
+- Check `node_modules/state-ref` exists
+- Check existing code imports from `state-ref`
+
+If `state-ref` is **not** installed, use the project's existing conventions. Do **not** suggest adding state-ref unless the user asks.
+
+---
+
+## Core Rules (Keep In Memory)
+
+- Create stores with `createStore<T>(initialValue)` for auto-sync mode.
+- Access values via `.value` property on `StateRefStore` proxies.
+- Subscribe with `watch(callback)` - callback receives `(stateRef, isFirst)`.
+- Subscription callbacks run once initially to collect dependencies.
+- Only tracked `.value` reads inside callbacks trigger re-runs on change.
+- Use `AbortController.signal` returned from callback to unsubscribe.
+- Use `createStoreManualSync()` for Flux-like patterns with `updateRef` and `sync()`.
+- Framework connectors: `connectReact`, `connectPreact`, `connectVue`, `connectSvelte`, `connectSolid`.
+- Combine watches with `combineWatch([watch1, watch2] as const)`.
+- Derive values with `createComputed([watches], callback)`.
+- Use `copyable()` for manual copy-on-write updates.
+- Avoid mutating state directly; always assign via `.value`.
+- When unsure, check `node_modules/state-ref/dist/index.d.ts`.
+
+---
+
+## Common Mistakes & Fixes
+
+### Always access values via `.value`
+
+```ts
+// BAD
+const age = stateRef.john.age;
+
+// GOOD
+const age = stateRef.john.age.value;
+```
+
+### Track dependencies inside subscription callback
+
+```ts
+// BAD - accessing .value outside callback won't track
+const externalRef = watch();
+watch((ref) => {
+  console.log(externalRef.count.value); // NOT tracked
+});
+
+// GOOD - use the callback's ref parameter
+watch((ref) => {
+  console.log(ref.count.value); // Tracked
+});
+```
+
+### Use AbortController for cleanup
+
+```ts
+const controller = new AbortController();
+watch((ref) => {
+  console.log(ref.value);
+  return controller.signal;
+});
+controller.abort(); // Unsubscribe
+```
+
+---
+
+## Quick Examples
+
+### Example 1: Basic Store and Subscription
+
+```ts
+import { createStore } from 'state-ref';
+
+const watch = createStore({ count: 0, name: 'John' });
+
+watch((ref, isFirst) => {
+  console.log('Count changed:', ref.count.value);
+});
+
+const ref = watch();
+ref.count.value = 10; // Triggers subscription
+```
+
+### Example 2: React Integration
+
+```ts
+import { createStore } from 'state-ref';
+import { connectReact } from '@stateref/connect-react';
+
+const watch = createStore({ age: 20 });
+export const useStore = connectReact(watch);
+
+// In component
+function Component() {
+  const { age } = useStore();
+  return <button onClick={() => age.value++}>{age.value}</button>;
+}
+```
+
+### Example 3: Manual Sync (Flux-like)
+
+```ts
+import { createStoreManualSync } from 'state-ref';
+
+const { watch, updateRef, sync } = createStoreManualSync({ count: 0 });
+
+export const increment = () => {
+  updateRef.count.value += 1;
+  sync(); // Notify subscribers
+};
+```
+
+---
+
+## Import Paths
+
+- Core: `import { createStore, createStoreManualSync, combineWatch, createComputed } from 'state-ref'`
+- Helpers: `import { lens, copyable, cloneDeep } from 'state-ref'`
+- React: `import { connectReact } from '@stateref/connect-react'`
+- Preact: `import { connectPreact } from '@stateref/connect-preact'`
+- Vue: `import { connectVue } from '@stateref/connect-vue'`
+- Svelte: `import { connectSvelte } from '@stateref/connect-svelte'`
+- Solid: `import { connectSolid } from '@stateref/connect-solid'`
+
+---
+
+## Summary
+
+Use `createStore` for reactive state, access via `.value`, subscribe with `watch(callback)`. Dependencies are tracked automatically inside callbacks. Use framework connectors for UI integration. For Flux patterns, use `createStoreManualSync`. Combine watches with `combineWatch` or derive computed values with `createComputed`.

--- a/skills/state-ref/constraints/common-mistakes.md
+++ b/skills/state-ref/constraints/common-mistakes.md
@@ -1,0 +1,78 @@
+# Common Mistakes and Fixes
+
+## Always access values via `.value`
+
+```ts
+// BAD - returns proxy, not the actual value
+const age = stateRef.john.age;
+
+// GOOD - returns the actual value
+const age = stateRef.john.age.value;
+```
+
+## Track dependencies inside subscription callback
+
+```ts
+// BAD - externalRef is not bound to any subscription
+const externalRef = watch();
+watch((ref) => {
+  console.log(externalRef.count.value); // NOT tracked!
+});
+
+// GOOD - use the callback's ref parameter (innerRef)
+watch((ref) => {
+  console.log(ref.count.value); // Tracked
+});
+```
+
+## Both innerRef and outerRef are the same reference
+
+```ts
+// innerRef (callback arg) and outerRef (return value) are identical
+const outerRef = watch((innerRef) => {
+  console.log(innerRef.count.value); // Tracked
+});
+
+// outerRef is also bound to the subscription
+outerRef.count.value = 10; // This change triggers the callback
+```
+
+## Use AbortController for cleanup
+
+```ts
+const controller = new AbortController();
+watch((ref) => {
+  console.log(ref.value);
+  return controller.signal; // Return signal for cleanup
+});
+
+controller.abort(); // Unsubscribe when needed
+```
+
+## Don't modify state directly in manual-sync mode
+
+```ts
+// BAD - watch refs are read-only in manual-sync mode
+const { watch } = createStoreManualSync({ count: 0 });
+const ref = watch();
+ref.count.value = 10; // Error!
+
+// GOOD - use updateRef and sync
+const { watch, updateRef, sync } = createStoreManualSync({ count: 0 });
+updateRef.count.value = 10;
+sync();
+```
+
+## Primitive stores access value directly
+
+```ts
+const watch = createStore<number>(3);
+
+watch((ref) => {
+  // BAD - ref itself is not the value
+  console.log(ref);
+
+  // GOOD - access .value directly
+  console.log(ref.value);
+});
+```

--- a/skills/state-ref/constraints/core-rules.md
+++ b/skills/state-ref/constraints/core-rules.md
@@ -1,0 +1,22 @@
+# Core Rules
+
+- Create stores with `createStore<T>(initialValue)` for auto-sync mode.
+- Access values via `.value` property on `StateRefStore` proxies.
+- Subscribe with `watch(callback)` where callback receives `(stateRef, isFirst)`.
+- Subscription callbacks run once initially to collect dependencies.
+- Only `.value` reads inside the callback parameter (`innerRef`) are tracked.
+- Reading `.value` from external refs (created by `watch()` without callback) won't track.
+- Use `AbortController.signal` returned from callback to unsubscribe.
+- Use `createStoreManualSync()` for Flux-like patterns.
+- In manual-sync mode, modify via `updateRef`, then call `sync()` to notify subscribers.
+- Framework connectors transform `watch` into framework-specific hooks/stores.
+- Use `combineWatch([watch1, watch2] as const)` to observe multiple stores together.
+- Use `createComputed([watches], callback)` to derive read-only computed values.
+- Use `copyable(obj)` for manual copy-on-write when needed.
+- Use `lens<T>()` for functional lens-style immutable updates.
+- Avoid mutating state directly; always assign via `.value`.
+- Primitive types (number, string) can be stored directly: `createStore<number>(3)`.
+- When unsure, check `node_modules/state-ref/dist/index.d.ts` for type signatures.
+
+Note: For simple state needs, native framework state (useState, ref, etc.) may suffice.
+Use state-ref when you need shared state across components or fine-grained reactivity.

--- a/skills/state-ref/constraints/troubleshooting.md
+++ b/skills/state-ref/constraints/troubleshooting.md
@@ -1,0 +1,23 @@
+# Troubleshooting (Fast Checks)
+
+- Is the value accessed via `.value`? (Not `.value` = proxy, not actual data)
+- Are dependencies tracked inside the callback's ref parameter?
+- Are you using an external ref that's not bound to the subscription?
+- Did you return `AbortController.signal` for cleanup?
+- In manual-sync mode, are you modifying via `updateRef` and calling `sync()`?
+- For primitives, are you accessing `ref.value` directly (not `ref.someProperty.value`)?
+- Are you using `as const` with `combineWatch` array for proper type inference?
+- Did framework connector return the right type? (React: hook, Vue: reactive, etc.)
+- Is the store properly exported and imported across modules?
+- Check `node_modules/state-ref/dist/index.d.ts` for type signatures.
+
+If subscription doesn't trigger:
+1. Verify `.value` is read inside the callback
+2. Verify the modified property was read (tracked) in the callback
+3. Verify you're using the callback's ref, not an external unbound ref
+4. Verify the subscription wasn't aborted
+
+If type errors occur:
+1. Add explicit generic: `createStore<MyType>(...)`
+2. Use `as const` with `combineWatch`
+3. Check StateRefStore<T> usage in custom code

--- a/skills/state-ref/examples/quick-examples.md
+++ b/skills/state-ref/examples/quick-examples.md
@@ -1,0 +1,151 @@
+# Quick Examples
+
+## Example 1: Basic Store and Subscription
+
+```ts
+import { createStore } from 'state-ref';
+
+type State = { count: number; user: { name: string } };
+
+const watch = createStore<State>({
+  count: 0,
+  user: { name: 'John' }
+});
+
+// Subscribe to changes
+watch((ref, isFirst) => {
+  console.log('Count:', ref.count.value);
+  console.log('Is first run:', isFirst);
+});
+
+// Modify state
+const ref = watch();
+ref.count.value = 10; // Triggers callback
+ref.user.name.value = 'Jane'; // Doesn't trigger (not tracked)
+```
+
+## Example 2: React Integration
+
+```ts
+// store.ts
+import { createStore } from 'state-ref';
+import { connectReact } from '@stateref/connect-react';
+
+const watch = createStore({
+  todos: [] as string[],
+  filter: 'all'
+});
+
+export const useTodoStore = connectReact(watch);
+
+// TodoList.tsx
+import { useTodoStore } from './store';
+
+function TodoList() {
+  const { todos, filter } = useTodoStore();
+
+  const addTodo = (text: string) => {
+    todos.value = [...todos.value, text];
+  };
+
+  return (
+    <div>
+      <ul>
+        {todos.value.map((todo, i) => (
+          <li key={i}>{todo}</li>
+        ))}
+      </ul>
+      <button onClick={() => addTodo('New Todo')}>Add</button>
+    </div>
+  );
+}
+```
+
+## Example 3: Flux-like Pattern
+
+```ts
+// store.ts
+import { createStoreManualSync } from 'state-ref';
+import { connectReact } from '@stateref/connect-react';
+
+type State = { count: number; loading: boolean };
+
+const { watch, updateRef, sync } = createStoreManualSync<State>({
+  count: 0,
+  loading: false
+});
+
+export const useStore = connectReact(watch);
+
+// Actions
+export const increment = () => {
+  updateRef.count.value += 1;
+  sync();
+};
+
+export const fetchData = async () => {
+  updateRef.loading.value = true;
+  sync();
+
+  await fetch('/api/data');
+
+  updateRef.loading.value = false;
+  updateRef.count.value = 100;
+  sync();
+};
+```
+
+## Example 4: Combining Multiple Stores
+
+```ts
+import { createStore, combineWatch } from 'state-ref';
+
+const userWatch = createStore({ name: 'John', age: 30 });
+const settingsWatch = createStore({ theme: 'dark', lang: 'en' });
+
+const combinedWatch = combineWatch([userWatch, settingsWatch] as const);
+
+combinedWatch(([userRef, settingsRef]) => {
+  console.log('User:', userRef.name.value);
+  console.log('Theme:', settingsRef.theme.value);
+});
+```
+
+## Example 5: Computed Values
+
+```ts
+import { createStore, createComputed } from 'state-ref';
+
+const priceWatch = createStore<number>(100);
+const quantityWatch = createStore<number>(5);
+
+const totalWatch = createComputed(
+  [priceWatch, quantityWatch],
+  ([priceRef, qtyRef]) => priceRef.value * qtyRef.value
+);
+
+totalWatch((ref) => {
+  console.log('Total:', ref.value); // 500
+});
+
+// Update price
+const priceRef = priceWatch();
+priceRef.value = 200; // Total becomes 1000
+```
+
+## Example 6: Cleanup with AbortController
+
+```ts
+import { createStore } from 'state-ref';
+
+const watch = createStore({ data: null });
+const controller = new AbortController();
+
+watch((ref) => {
+  console.log('Data changed:', ref.data.value);
+  return controller.signal;
+});
+
+// Later, when component unmounts or cleanup needed:
+controller.abort();
+```

--- a/skills/state-ref/reference/framework-connectors.md
+++ b/skills/state-ref/reference/framework-connectors.md
@@ -1,0 +1,109 @@
+# Framework Connectors
+
+Each connector transforms `watch` into framework-specific reactive primitives.
+
+## React / Preact
+
+```ts
+import { createStore } from 'state-ref';
+import { connectReact } from '@stateref/connect-react';
+// import { connectPreact } from '@stateref/connect-preact';
+
+const watch = createStore({ count: 0 });
+export const useStore = connectReact(watch);
+
+// In component
+function Counter() {
+  const { count } = useStore();
+  return (
+    <button onClick={() => count.value++}>
+      {count.value}
+    </button>
+  );
+}
+```
+
+Returns `StateRefStore` directly via hook.
+
+## Vue
+
+```ts
+import { createStore } from 'state-ref';
+import { connectVue } from '@stateref/connect-vue';
+
+const watch = createStore({ count: 0 });
+export const useStore = connectVue(watch);
+
+// In component
+const store = useStore();
+// store is Vue Reactive object
+```
+
+Returns Vue `Reactive` objects.
+
+## Svelte
+
+```ts
+import { createStore } from 'state-ref';
+import { connectSvelte } from '@stateref/connect-svelte';
+
+const watch = createStore({ count: 0 });
+export const store = connectSvelte(watch);
+
+// In Svelte component
+// $store.count.value
+```
+
+Returns Svelte `Writable` stores.
+
+## Solid
+
+```ts
+import { createStore } from 'state-ref';
+import { connectSolid } from '@stateref/connect-solid';
+
+const watch = createStore({ count: 0 });
+export const useStore = connectSolid(watch);
+
+// In component
+const [store, setStore] = useStore();
+```
+
+Returns Solid `Signal` pairs.
+
+## Lithent
+
+Lithent uses `watch` directly without connector.
+
+```tsx
+import { mount } from 'lithent';
+import { watch } from './store';
+
+const Counter = mount((renew) => {
+  const { count } = watch(renew);
+
+  return () => (
+    <button onClick={() => count.value++}>
+      {count.value}
+    </button>
+  );
+});
+```
+
+## Custom Connectors
+
+Create your own by following the pattern:
+
+```ts
+export const connectCustom = <T>(watch: Watch<T>) => {
+  return () => {
+    // 1. Create framework-specific state
+    // 2. Subscribe to watch with framework's update mechanism
+    // 3. Return framework-appropriate value
+  };
+};
+```
+
+Reference implementations:
+- `packages/connect-react/src/index.ts`
+- `packages/connect-preact/src/index.ts`

--- a/skills/state-ref/reference/store-creation.md
+++ b/skills/state-ref/reference/store-creation.md
@@ -1,0 +1,106 @@
+# Store Creation
+
+## createStore (Auto-Sync Mode)
+
+Default mode where changes immediately trigger subscribers.
+
+```ts
+import { createStore } from 'state-ref';
+
+// Object state
+const watch = createStore<{ count: number; name: string }>({
+  count: 0,
+  name: 'John'
+});
+
+// Primitive state
+const watchNumber = createStore<number>(42);
+const watchString = createStore<string>('hello');
+```
+
+### Usage
+
+```ts
+// Subscribe
+watch((ref) => {
+  console.log(ref.count.value, ref.name.value);
+});
+
+// Modify (auto-syncs to subscribers)
+const ref = watch();
+ref.count.value = 10;
+```
+
+## createStoreManualSync (Manual-Sync Mode)
+
+Flux-like pattern where you control when updates propagate.
+
+```ts
+import { createStoreManualSync } from 'state-ref';
+
+const { watch, updateRef, sync } = createStoreManualSync<{
+  count: number;
+}>({ count: 0 });
+```
+
+### Returns
+
+- `watch`: Subscribe to state (read-only refs)
+- `updateRef`: Writable reference for modifications
+- `sync`: Function to notify all subscribers
+
+### Usage
+
+```ts
+// Subscribe (refs are read-only)
+watch((ref) => {
+  console.log(ref.count.value);
+});
+
+// Modify via updateRef, then sync
+updateRef.count.value = 10;
+sync(); // Triggers subscribers
+
+// Direct modification via watch() throws error
+const ref = watch();
+ref.count.value = 5; // Error!
+```
+
+## combineWatch
+
+Combine multiple watches into one.
+
+```ts
+import { createStore, combineWatch } from 'state-ref';
+
+const countWatch = createStore<number>(0);
+const textWatch = createStore<string>('hello');
+
+const combined = combineWatch([countWatch, textWatch] as const);
+
+combined(([countRef, textRef]) => {
+  console.log(countRef.value, textRef.value);
+});
+```
+
+## createComputed
+
+Derive computed values from multiple watches.
+
+```ts
+import { createStore, createComputed } from 'state-ref';
+
+const aWatch = createStore<number>(10);
+const bWatch = createStore<number>(20);
+
+const sumWatch = createComputed(
+  [aWatch, bWatch],
+  ([aRef, bRef]) => aRef.value + bRef.value
+);
+
+sumWatch((ref) => {
+  console.log('Sum:', ref.value); // 30
+});
+```
+
+Computed values are read-only.

--- a/skills/state-ref/reference/watch-function.md
+++ b/skills/state-ref/reference/watch-function.md
@@ -1,0 +1,71 @@
+# Watch Function
+
+The `watch` function returned by `createStore()` is the core abstraction for reactivity.
+
+## Two Usage Modes
+
+### 1. With Callback (Subscribe)
+
+```ts
+const watch = createStore({ count: 0 });
+
+// Subscribe to changes
+const outerRef = watch((innerRef, isFirst) => {
+  console.log('Count:', innerRef.count.value);
+  // isFirst is true on initial run, false on subsequent updates
+});
+```
+
+- Callback runs immediately once to collect dependencies
+- Callback re-runs when any tracked `.value` changes
+- `innerRef` and `outerRef` are the same reference, both bound to subscription
+
+### 2. Without Callback (Get Reference)
+
+```ts
+const ref = watch();
+// ref is NOT bound to any subscription
+// Useful for reading/writing from outside callbacks
+```
+
+## Callback Signature
+
+```ts
+type Renew<T> = (
+  stateRef: StateRefStore<T>,
+  isFirst: boolean
+) => AbortSignal | void;
+```
+
+- `stateRef`: Proxied reference to state
+- `isFirst`: `true` on first run, `false` on updates
+- Return `AbortSignal` to enable unsubscription
+
+## Unsubscription
+
+```ts
+const controller = new AbortController();
+
+watch((ref) => {
+  console.log(ref.value);
+  return controller.signal;
+});
+
+// Later...
+controller.abort(); // Stop receiving updates
+```
+
+## Dependency Tracking
+
+Only `.value` reads inside the callback are tracked:
+
+```ts
+watch((ref) => {
+  // These are tracked:
+  const a = ref.user.name.value;
+  const b = ref.settings.theme.value;
+
+  // This proxy access without .value is NOT tracked:
+  const proxy = ref.user.age; // Just returns proxy
+});
+```

--- a/state-ref-agent-addon.md
+++ b/state-ref-agent-addon.md
@@ -1,0 +1,311 @@
+# state-ref Agent Role Add-on
+
+## What This Document Is
+
+This document is a **reusable Agent Role Add-on** designed to guide state-ref reactive state management patterns in AI coding agents.
+
+This is not:
+- A human-readable tutorial
+- An API reference
+- A complete agent specification
+- Framework-specific instructions
+
+This is:
+- A self-contained behavior module
+- Copy-paste ready instructions for agent system prompts
+- A composable extension that modifies existing agent roles
+- A conditional guide that activates only when state-ref is detected
+
+This add-on transforms any general-purpose coding agent into one that prioritizes state-ref's proxy-based reactivity and lens pattern **when state-ref is installed in the project**. No external documentation is required—all necessary context is embedded within this document.
+
+## When to Use This Add-on
+
+**Attach this add-on to your agent when:**
+- You work across multiple projects, some using state-ref and others not
+- You want automatic pattern guidance when state-ref is detected
+- Your team adopts state-ref selectively per project
+- You need a single agent configuration that adapts to project context
+
+**This add-on automatically activates only when state-ref is installed.**
+
+The agent will:
+- Detect state-ref presence via `package.json` or `node_modules`
+- Suggest state-ref patterns only in projects with state-ref installed
+- Use standard state management practices in projects without state-ref
+- Never suggest installing state-ref unless explicitly requested
+
+**Do not attach this add-on when:**
+- You exclusively work on projects that never use state-ref
+- You prefer manual control over when to apply reactive patterns
+- Your agent configuration is project-specific rather than global
+
+## state-ref Coding Behavior (Copy-Paste Block)
+
+```
+You are a coding agent with state-ref reactive state management guidance enabled.
+
+ACTIVATION CONDITIONS:
+
+These guidelines apply ONLY when state-ref is installed in the current project.
+
+Before suggesting state-ref patterns, verify state-ref availability:
+1. Check if `package.json` contains state-ref in dependencies or devDependencies
+2. Check if `node_modules/state-ref` directory exists
+3. Check if state-ref imports are present in existing code
+
+If state-ref is NOT installed:
+- Do not enforce these guidelines
+- Use standard state management practices appropriate for the project
+- Never suggest installing state-ref unless explicitly requested
+
+If state-ref IS installed:
+- Apply all guidelines below
+- Suggest state-ref alternatives for complex state management
+- Prioritize fine-grained reactivity patterns for clarity and performance
+
+CODING GUIDELINES:
+
+1. STORE CREATION
+   - Use `createStore<T>(initialValue)` for auto-sync mode (default)
+   - Use `createStoreManualSync<T>(initialValue)` for Flux-like patterns
+   - Always specify generic type for complex objects
+   - Primitive types (number, string) work directly
+
+2. VALUE ACCESS
+   - Always access values via `.value` property
+   - `stateRef.user.name` returns proxy, not the actual value
+   - `stateRef.user.name.value` returns the actual value
+   - Assignments must also use `.value`: `ref.count.value = 10`
+
+3. SUBSCRIPTION PATTERNS
+   - Use `watch(callback)` to subscribe to changes
+   - Callback signature: `(stateRef, isFirst) => AbortSignal | void`
+   - `isFirst` is true on initial run, false on subsequent updates
+   - Only `.value` reads inside callback are tracked as dependencies
+   - Return `AbortController.signal` for cleanup/unsubscription
+
+4. DEPENDENCY TRACKING
+   - Use the callback's ref parameter (innerRef), not external refs
+   - External refs created by `watch()` without callback are NOT tracked
+   - Both innerRef (callback arg) and outerRef (return value) are same reference
+   - Changes to non-tracked properties don't trigger re-runs
+
+5. MANUAL SYNC MODE (FLUX-LIKE)
+   - Destructure: `const { watch, updateRef, sync } = createStoreManualSync(...)`
+   - `watch` refs are read-only in this mode
+   - Modify state only via `updateRef`
+   - Call `sync()` to notify all subscribers
+   - Create action functions that encapsulate updateRef + sync
+
+6. FRAMEWORK INTEGRATION
+   - React/Preact: `const useStore = connectReact(watch)`
+   - Vue: `const useStore = connectVue(watch)`
+   - Svelte: `const store = connectSvelte(watch)`
+   - Solid: `const useStore = connectSolid(watch)`
+   - Lithent: Use `watch(renew)` directly
+
+7. COMBINING STORES
+   - Use `combineWatch([watch1, watch2] as const)` for multiple stores
+   - Use `as const` for proper TypeScript inference
+   - Nested combinations are supported
+
+8. COMPUTED VALUES
+   - Use `createComputed([watches], callback)` for derived values
+   - Computed values are read-only
+   - Can be used with framework connectors like regular watches
+
+9. IMMUTABILITY
+   - state-ref uses copy-on-write internally
+   - Avoid direct mutation; always assign via `.value`
+   - Use `copyable()` helper for manual copy-on-write when needed
+   - Use `lens()` for functional lens-style immutable updates
+
+10. PRACTICAL BALANCE
+    - Use state-ref for shared state across components
+    - Simple local state can use native framework state (useState, ref, etc.)
+    - Don't overcomplicate simple scenarios
+
+IMPORT PATHS:
+- Core: `import { createStore, createStoreManualSync, combineWatch, createComputed } from 'state-ref'`
+- Helpers: `import { lens, copyable, cloneDeep } from 'state-ref'`
+- React: `import { connectReact } from '@stateref/connect-react'`
+- Preact: `import { connectPreact } from '@stateref/connect-preact'`
+- Vue: `import { connectVue } from '@stateref/connect-vue'`
+- Svelte: `import { connectSvelte } from '@stateref/connect-svelte'`
+- Solid: `import { connectSolid } from '@stateref/connect-solid'`
+
+GUIDANCE APPROACH:
+When user requests could benefit from state-ref patterns:
+1. Provide solution using state-ref patterns
+2. Explain advantages of the reactive approach
+3. If user prefers other state management, respect their choice
+
+When existing code could be improved with state-ref:
+1. Suggest state-ref refactoring when it adds clarity or performance
+2. Explain the benefits of fine-grained reactivity
+3. Don't force refactoring for trivial improvements
+
+REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
+
+For detailed guidance on state-ref patterns and usage, refer to:
+node_modules/state-ref/dist/skills/state-ref/
+
+This reference material provides comprehensive examples, troubleshooting tips,
+and pattern guidance that complements the behavioral guidelines above.
+```
+
+## Minimal state-ref Interface Context
+
+This section provides minimal context to help agents locate and use state-ref functions without becoming an API reference.
+
+### Store Creation
+- **createStore** - Create auto-sync store (changes immediately notify subscribers)
+- **createStoreManualSync** - Create manual-sync store (Flux-like, explicit sync)
+
+### Watch Function
+- **watch(callback)** - Subscribe to state changes, returns bound StateRefStore
+- **watch()** - Get unbound StateRefStore reference (no tracking)
+
+### Combining & Computing
+- **combineWatch** - Combine multiple watches into single watch
+- **createComputed** - Derive computed values from multiple watches
+
+### Helper Functions
+- **lens** - Functional lens for immutable updates
+- **copyable** - Manual copy-on-write helper
+- **cloneDeep** - Deep clone utility
+
+### Framework Connectors
+- **connectReact** - React hook connector (`@stateref/connect-react`)
+- **connectPreact** - Preact hook connector (`@stateref/connect-preact`)
+- **connectVue** - Vue reactive connector (`@stateref/connect-vue`)
+- **connectSvelte** - Svelte store connector (`@stateref/connect-svelte`)
+- **connectSolid** - Solid signal connector (`@stateref/connect-solid`)
+
+### Key Types
+- **StateRefStore<T>** - Proxied reference with `.value` accessor
+- **Watch<T>** - Watch function type
+- **Renew<T>** - Subscription callback type
+
+## How to Attach This Add-on
+
+### Integration Pattern
+
+Insert the "state-ref Coding Behavior" block into your agent's system prompt:
+
+```
+<your-existing-agent-role>
+  <identity>
+    You are a [your agent description]...
+  </identity>
+
+  <capabilities>
+    [your agent capabilities]...
+  </capabilities>
+
+  <!-- INSERT state-ref BEHAVIORAL GUIDELINES HERE -->
+  <coding-guidelines>
+    [Copy the entire "state-ref Coding Behavior (Copy-Paste Block)" section here]
+  </coding-guidelines>
+
+  <workflow>
+    [your agent workflow]...
+  </workflow>
+</your-existing-agent-role>
+```
+
+### Configuration Files
+
+For agent configuration files (YAML, JSON, etc.), adapt the guidelines to the format:
+
+```yaml
+agent:
+  role: "Your Agent Role"
+  extensions:
+    - type: "state-ref-addon"
+      content: |
+        [Paste state-ref Coding Behavior guidelines here]
+```
+
+### Multiple Add-ons
+
+This add-on composes with other role extensions:
+
+```
+<agent-role>
+  <base-role>Your agent identity</base-role>
+  <extension name="state-ref-addon">[state-ref guidelines]</extension>
+  <extension name="security-addon">[security guidelines]</extension>
+  <extension name="testing-addon">[testing guidelines]</extension>
+</agent-role>
+```
+
+## Design Philosophy
+
+### Why an Add-on, Not a Complete Agent Role?
+
+This document is structured as an add-on rather than a complete agent definition because:
+
+1. **Role Personalization**: Different teams have different agent personalities, capabilities, and workflows. A complete agent specification would impose unnecessary constraints on these preferences.
+
+2. **Composition Over Prescription**: Agent roles should be composable. This add-on focuses solely on guiding state-ref patterns, allowing users to combine it with other behavioral extensions (testing strategies, security policies, documentation standards).
+
+3. **Framework Agnostic**: Complete agent definitions often include framework-specific instructions or tool configurations. This add-on remains purely focused on coding behavior, independent of execution environment.
+
+4. **Maintenance Simplicity**: Behavioral guidelines change less frequently than tool configurations or framework integrations. Separating concerns allows independent versioning and updates.
+
+5. **Reusability Across Platforms**: Different AI platforms (Claude Code, custom agents, IDE extensions) have different configuration formats. A standalone behavioral module adapts more easily than a complete agent specification.
+
+### Guidance vs. Enforcement
+
+This add-on provides guidance rather than strict enforcement. The distinction is critical:
+
+- **Guidance**: Agent suggests state-ref patterns and explains benefits
+- **Enforcement**: Agent refuses to generate code that violates constraints
+
+state-ref patterns benefit from guidance because:
+- **Flexibility**: Some situations genuinely benefit from simpler state management
+- **Learning curve**: Developers need time to understand reactive patterns
+- **Pragmatism**: Simple local state doesn't always need shared stores
+- **Context matters**: Not every component needs state-ref
+
+### Balanced Approach
+
+This add-on follows the state-ref SKILL.md philosophy:
+- Use state-ref for shared state across components
+- Simple local state can use native framework state
+- Don't overcomplicate simple scenarios
+
+**Why balanced over strict?**
+1. **Readability first**: Reactive patterns should enhance, not obscure
+2. **Respect developer judgment**: Not every state needs to be shared
+3. **Gradual adoption**: Teams can adopt state-ref incrementally
+4. **Avoid dogma**: Pragmatism over purity
+
+### Selective Activation Based on Project Context
+
+This add-on activates conditionally based on state-ref installation status:
+
+**Why selective activation?**
+1. **Avoid forcing dependencies**: Agents should not impose architectural decisions on projects that haven't adopted state-ref
+2. **Respect existing patterns**: Projects without state-ref likely have established state management conventions that should be honored
+3. **Prevent confusion**: Suggesting state-ref patterns without state-ref available creates import errors and confusion
+4. **Enable experimentation**: Teams can evaluate state-ref by installing it, triggering automatic pattern guidance
+
+**Detection mechanism:**
+The agent verifies state-ref availability through:
+- `package.json` dependency declarations (most reliable)
+- `node_modules` directory presence (installation confirmation)
+- Existing import statements (usage confirmation)
+
+This detection-based activation allows a single agent configuration to work appropriately across multiple projects with different technology stacks.
+
+### Design Constraints
+
+This add-on intentionally avoids:
+- **Complete API coverage**: Full API documentation belongs in separate references (skills/state-ref/ reference files)
+- **Framework-specific patterns**: UI framework integration belongs in project-specific documentation
+- **Implementation details**: Internal state-ref architecture is irrelevant to usage
+- **Absolute prohibitions**: "Never" statements reduce flexibility and pragmatism
+
+The goal is minimal, actionable guidance that modifies agent behavior without overwhelming the context window or duplicating external documentation.

--- a/stateRefDocs/src/components/Layout.tsx
+++ b/stateRefDocs/src/components/Layout.tsx
@@ -52,6 +52,10 @@ import { ApiHelpers } from '@/pages/ApiHelpers';
 import { ApiHelpersKo } from '@/pages/ApiHelpers_ko';
 import { ApiTypes } from '@/pages/ApiTypes';
 import { ApiTypesKo } from '@/pages/ApiTypes_ko';
+import { AIAgentSkills } from '@/pages/AIAgentSkills';
+import { AIAgentSkillsKo } from '@/pages/AIAgentSkills_ko';
+import { AIAgentAddon } from '@/pages/AIAgentAddon';
+import { AIAgentAddonKo } from '@/pages/AIAgentAddon_ko';
 
 type PageComponent = (...args: any[]) => any;
 
@@ -112,6 +116,10 @@ const routes: Record<string, PageComponent> = {
   '/ko/api/helpers': ApiHelpersKo,
   '/api/types': ApiTypes,
   '/ko/api/types': ApiTypesKo,
+  '/ai-agent-skills': AIAgentSkills,
+  '/ko/ai-agent-skills': AIAgentSkillsKo,
+  '/ai-agent-addon': AIAgentAddon,
+  '/ko/ai-agent-addon': AIAgentAddonKo,
 };
 
 const resolveRoute = (path: string): PageComponent => {

--- a/stateRefDocs/src/components/Sidebar.tsx
+++ b/stateRefDocs/src/components/Sidebar.tsx
@@ -23,6 +23,14 @@ const menuData: MenuSection[] = [
         link: 'https://github.com/superlucky84/state-ref',
         external: true,
       },
+      {
+        text: { en: 'AI Agent Skills', ko: 'AI Agent Skills' },
+        link: '/ai-agent-skills',
+      },
+      {
+        text: { en: 'AI Agent Role Add-on', ko: 'AI Agent Role Add-on' },
+        link: '/ai-agent-addon',
+      },
     ],
   },
   {

--- a/stateRefDocs/src/pages/AIAgentAddon.tsx
+++ b/stateRefDocs/src/pages/AIAgentAddon.tsx
@@ -1,0 +1,303 @@
+import { CodeBlock } from '@/components/CodeBlock';
+
+const ADDON_CODE = `You are a coding agent with state-ref reactive state management guidance enabled.
+
+ACTIVATION CONDITIONS:
+
+These guidelines apply ONLY when state-ref is installed in the current project.
+
+Before suggesting state-ref patterns, verify state-ref availability:
+1. Check if \`package.json\` contains state-ref in dependencies or devDependencies
+2. Check if \`node_modules/state-ref\` directory exists
+3. Check if state-ref imports are present in existing code
+
+If state-ref is NOT installed:
+- Do not enforce these guidelines
+- Use standard state management practices appropriate for the project
+- Never suggest installing state-ref unless explicitly requested
+
+If state-ref IS installed:
+- Apply all guidelines below
+- Suggest state-ref alternatives for complex state management
+- Prioritize fine-grained reactivity patterns for clarity and performance
+
+CODING GUIDELINES:
+
+1. STORE CREATION
+   - Use \`createStore<T>(initialValue)\` for auto-sync mode (default)
+   - Use \`createStoreManualSync<T>(initialValue)\` for Flux-like patterns
+   - Always specify generic type for complex objects
+   - Primitive types (number, string) work directly
+
+2. VALUE ACCESS
+   - Always access values via \`.value\` property
+   - \`stateRef.user.name\` returns proxy, not the actual value
+   - \`stateRef.user.name.value\` returns the actual value
+   - Assignments must also use \`.value\`: \`ref.count.value = 10\`
+
+3. SUBSCRIPTION PATTERNS
+   - Use \`watch(callback)\` to subscribe to changes
+   - Callback signature: \`(stateRef, isFirst) => AbortSignal | void\`
+   - \`isFirst\` is true on initial run, false on subsequent updates
+   - Only \`.value\` reads inside callback are tracked as dependencies
+   - Return \`AbortController.signal\` for cleanup/unsubscription
+
+4. DEPENDENCY TRACKING
+   - Use the callback's ref parameter (innerRef), not external refs
+   - External refs created by \`watch()\` without callback are NOT tracked
+   - Both innerRef (callback arg) and outerRef (return value) are same reference
+   - Changes to non-tracked properties don't trigger re-runs
+
+5. MANUAL SYNC MODE (FLUX-LIKE)
+   - Destructure: \`const { watch, updateRef, sync } = createStoreManualSync(...)\`
+   - \`watch\` refs are read-only in this mode
+   - Modify state only via \`updateRef\`
+   - Call \`sync()\` to notify all subscribers
+   - Create action functions that encapsulate updateRef + sync
+
+6. FRAMEWORK INTEGRATION
+   - React/Preact: \`const useStore = connectReact(watch)\`
+   - Vue: \`const useStore = connectVue(watch)\`
+   - Svelte: \`const store = connectSvelte(watch)\`
+   - Solid: \`const useStore = connectSolid(watch)\`
+   - Lithent: Use \`watch(renew)\` directly
+
+IMPORT PATHS:
+- Core: \`import { createStore, createStoreManualSync, combineWatch, createComputed } from 'state-ref'\`
+- Helpers: \`import { lens, copyable, cloneDeep } from 'state-ref'\`
+- React: \`import { connectReact } from '@stateref/connect-react'\`
+- Preact: \`import { connectPreact } from '@stateref/connect-preact'\`
+- Vue: \`import { connectVue } from '@stateref/connect-vue'\`
+- Svelte: \`import { connectSvelte } from '@stateref/connect-svelte'\`
+- Solid: \`import { connectSolid } from '@stateref/connect-solid'\`
+
+GUIDANCE APPROACH:
+When user requests could benefit from state-ref patterns:
+1. Provide solution using state-ref patterns
+2. Explain advantages of the reactive approach
+3. If user prefers other state management, respect their choice
+
+REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
+
+For detailed guidance on state-ref patterns and usage, refer to:
+node_modules/state-ref/dist/skills/state-ref/
+
+This reference material provides comprehensive examples, troubleshooting tips,
+and pattern guidance that complements the behavioral guidelines above.`;
+
+export const AIAgentAddon = () => (
+  <div class="prose prose-lg dark:prose-invert max-w-none">
+    <h1 class="text-3xl md:text-4xl font-semibold text-gray-900 dark:text-white mb-6">
+      AI Agent Role Add-on
+    </h1>
+
+    <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
+      A reusable behavior module that conditionally guides state-ref patterns in AI coding agents
+    </p>
+
+    <div class="bg-purple-50 dark:bg-purple-900/20 p-6 rounded-lg border border-purple-200 dark:border-purple-800 mb-8">
+      <h3 class="text-lg font-medium text-purple-900 dark:text-purple-200 mb-2">
+        Experimental by Design
+      </h3>
+      <p class="text-sm text-purple-800 dark:text-purple-300">
+        This specification explores how state-ref can be applied as a first-class behavioral constraint for AI coding agents.
+      </p>
+    </div>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      What is Agent Role Add-on?
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      The state-ref Agent Role Add-on is a copy-paste ready behavior extension for AI coding agents (OpenCode, custom agents, IDE extensions, etc.). Unlike skills packages that are project-specific, this add-on is attached directly to your agent's system prompt, making it work across all your projects.
+    </p>
+
+    <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mb-6">
+      <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
+        <span class="font-medium">Key Difference:</span> Skills files are per-project configurations. Agent add-ons are global agent behaviors that activate conditionally based on project context.
+      </p>
+    </div>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      Key Features
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li><strong>Conditional Activation:</strong> Only suggests state-ref patterns when state-ref is detected in the project</li>
+      <li><strong>Auto-Detection:</strong> Checks <code class="text-sm">package.json</code>, <code class="text-sm">node_modules</code>, and existing imports</li>
+      <li><strong>Respects Non-state-ref Projects:</strong> Uses standard coding practices when state-ref isn't installed</li>
+      <li><strong>Single Configuration:</strong> Works across multiple projects with different technology stacks</li>
+      <li><strong>Copy-Paste Ready:</strong> No complex setup, just paste into your agent's system prompt</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      When to Use This Add-on
+    </h2>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      Use When:
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>You work across multiple projects, some using state-ref and others not</li>
+      <li>You want automatic pattern guidance when state-ref is detected</li>
+      <li>Your team adopts state-ref selectively per project</li>
+      <li>You need a single agent configuration that adapts to project context</li>
+    </ul>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      Don't Use When:
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>You exclusively work on projects that never use state-ref</li>
+      <li>You prefer manual control over when to apply reactive patterns</li>
+      <li>Your agent configuration is project-specific rather than global</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      How to Attach This Add-on
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      Copy the behavioral constraints block below and paste it into your AI agent's system prompt or configuration.
+    </p>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      Copy This Block
+    </h3>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+      Copy the entire add-on configuration below:
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={ADDON_CODE}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Integration Examples
+    </h2>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      OpenCode (.opencode/config.yaml)
+    </h3>
+
+    <CodeBlock
+      language="bash"
+      code={`agent:
+  role: "Your Agent Role"
+  extensions:
+    - type: "state-ref-addon"
+      content: |
+        [Paste the state-ref constraints block here]`}
+    />
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      Custom Agent System Prompt
+    </h3>
+
+    <CodeBlock
+      language="bash"
+      code={`<your-existing-agent-role>
+  <identity>
+    You are a [your agent description]...
+  </identity>
+
+  <capabilities>
+    [your agent capabilities]...
+  </capabilities>
+
+  <!-- INSERT state-ref BEHAVIORAL CONSTRAINTS HERE -->
+  <coding-constraints>
+    [Paste the state-ref constraints block here]
+  </coding-constraints>
+
+  <workflow>
+    [your agent workflow]...
+  </workflow>
+</your-existing-agent-role>`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      How It Works
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      The add-on uses conditional logic to adapt its behavior based on the project context:
+    </p>
+
+    <div class="space-y-6 mb-6">
+      <div class="bg-green-50 dark:bg-green-900/20 p-6 rounded-lg border border-green-200 dark:border-green-800">
+        <h4 class="text-lg font-medium text-green-900 dark:text-green-200 mb-2">
+          When state-ref is installed
+        </h4>
+        <p class="text-sm text-green-800 dark:text-green-300">
+          The agent suggests state-ref patterns, explains benefits of reactive approaches, and respects user preferences while prioritizing fine-grained reactivity for clarity.
+        </p>
+      </div>
+
+      <div class="bg-gray-50 dark:bg-gray-800/20 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <h4 class="text-lg font-medium text-gray-900 dark:text-gray-200 mb-2">
+          When state-ref is NOT installed
+        </h4>
+        <p class="text-sm text-gray-700 dark:text-gray-400">
+          The agent uses standard coding practices appropriate for the project, never mentions state-ref, and respects existing conventions.
+        </p>
+      </div>
+    </div>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      Detection Mechanism
+    </h3>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+      The agent verifies state-ref availability through:
+    </p>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li><code class="text-sm">package.json</code> dependency declarations (most reliable)</li>
+      <li><code class="text-sm">node_modules</code> directory presence (installation confirmation)</li>
+      <li>Existing import statements (usage confirmation)</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Full Documentation
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      The complete add-on documentation is available at <code class="text-sm">node_modules/state-ref/dist/ai-addons/state-ref-agent-addon.md</code> after installation.
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      You can also view it in the{' '}
+      <a
+        href="https://github.com/superlucky84/state-ref/blob/main/state-ref-agent-addon.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        GitHub repository
+      </a>.
+    </p>
+
+    <div class="bg-yellow-50 dark:bg-yellow-900/20 p-6 rounded-lg border border-yellow-200 dark:border-yellow-800 mt-6">
+      <p class="text-sm md:text-base text-yellow-900 dark:text-yellow-200 leading-relaxed">
+        <span class="font-medium">Important:</span> This add-on is designed for agents with system prompt support. For project-specific AI assistance (like Claude Code's skills), use the <a href="#/ai-agent-skills" class="text-yellow-700 dark:text-yellow-300 hover:underline">AI Agent Skills</a> file instead.
+      </p>
+    </div>
+  </div>
+);

--- a/stateRefDocs/src/pages/AIAgentAddon_ko.tsx
+++ b/stateRefDocs/src/pages/AIAgentAddon_ko.tsx
@@ -1,0 +1,304 @@
+import { CodeBlock } from '@/components/CodeBlock';
+
+const ADDON_CODE = `You are a coding agent with state-ref reactive state management guidance enabled.
+
+ACTIVATION CONDITIONS:
+
+These guidelines apply ONLY when state-ref is installed in the current project.
+
+Before suggesting state-ref patterns, verify state-ref availability:
+1. Check if \`package.json\` contains state-ref in dependencies or devDependencies
+2. Check if \`node_modules/state-ref\` directory exists
+3. Check if state-ref imports are present in existing code
+
+If state-ref is NOT installed:
+- Do not enforce these guidelines
+- Use standard state management practices appropriate for the project
+- Never suggest installing state-ref unless explicitly requested
+
+If state-ref IS installed:
+- Apply all guidelines below
+- Suggest state-ref alternatives for complex state management
+- Prioritize fine-grained reactivity patterns for clarity and performance
+
+CODING GUIDELINES:
+
+1. STORE CREATION
+   - Use \`createStore<T>(initialValue)\` for auto-sync mode (default)
+   - Use \`createStoreManualSync<T>(initialValue)\` for Flux-like patterns
+   - Always specify generic type for complex objects
+   - Primitive types (number, string) work directly
+
+2. VALUE ACCESS
+   - Always access values via \`.value\` property
+   - \`stateRef.user.name\` returns proxy, not the actual value
+   - \`stateRef.user.name.value\` returns the actual value
+   - Assignments must also use \`.value\`: \`ref.count.value = 10\`
+
+3. SUBSCRIPTION PATTERNS
+   - Use \`watch(callback)\` to subscribe to changes
+   - Callback signature: \`(stateRef, isFirst) => AbortSignal | void\`
+   - \`isFirst\` is true on initial run, false on subsequent updates
+   - Only \`.value\` reads inside callback are tracked as dependencies
+   - Return \`AbortController.signal\` for cleanup/unsubscription
+
+4. DEPENDENCY TRACKING
+   - Use the callback's ref parameter (innerRef), not external refs
+   - External refs created by \`watch()\` without callback are NOT tracked
+   - Both innerRef (callback arg) and outerRef (return value) are same reference
+   - Changes to non-tracked properties don't trigger re-runs
+
+5. MANUAL SYNC MODE (FLUX-LIKE)
+   - Destructure: \`const { watch, updateRef, sync } = createStoreManualSync(...)\`
+   - \`watch\` refs are read-only in this mode
+   - Modify state only via \`updateRef\`
+   - Call \`sync()\` to notify all subscribers
+   - Create action functions that encapsulate updateRef + sync
+
+6. FRAMEWORK INTEGRATION
+   - React/Preact: \`const useStore = connectReact(watch)\`
+   - Vue: \`const useStore = connectVue(watch)\`
+   - Svelte: \`const store = connectSvelte(watch)\`
+   - Solid: \`const useStore = connectSolid(watch)\`
+   - Lithent: Use \`watch(renew)\` directly
+
+IMPORT PATHS:
+- Core: \`import { createStore, createStoreManualSync, combineWatch, createComputed } from 'state-ref'\`
+- Helpers: \`import { lens, copyable, cloneDeep } from 'state-ref'\`
+- React: \`import { connectReact } from '@stateref/connect-react'\`
+- Preact: \`import { connectPreact } from '@stateref/connect-preact'\`
+- Vue: \`import { connectVue } from '@stateref/connect-vue'\`
+- Svelte: \`import { connectSvelte } from '@stateref/connect-svelte'\`
+- Solid: \`import { connectSolid } from '@stateref/connect-solid'\`
+
+GUIDANCE APPROACH:
+When user requests could benefit from state-ref patterns:
+1. Provide solution using state-ref patterns
+2. Explain advantages of the reactive approach
+3. If user prefers other state management, respect their choice
+
+REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
+
+For detailed guidance on state-ref patterns and usage, refer to:
+node_modules/state-ref/dist/skills/state-ref/
+
+This reference material provides comprehensive examples, troubleshooting tips,
+and pattern guidance that complements the behavioral guidelines above.`;
+
+export const AIAgentAddonKo = () => (
+  <div class="prose prose-lg dark:prose-invert max-w-none">
+    <h1 class="text-3xl md:text-4xl font-semibold text-gray-900 dark:text-white mb-6">
+      AI Agent Role Add-on
+    </h1>
+
+    <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
+      AI 코딩 에이전트에서 state-ref 패턴을 조건부로 가이드하는 재사용 가능한 행동 모듈
+    </p>
+
+    <div class="bg-purple-50 dark:bg-purple-900/20 p-6 rounded-lg border border-purple-200 dark:border-purple-800 mb-8">
+      <h3 class="text-lg font-medium text-purple-900 dark:text-purple-200 mb-2">
+        실험적 기능
+      </h3>
+      <p class="text-sm text-purple-800 dark:text-purple-300">
+        이 스펙은 state-ref가 AI 코딩 에이전트의 일급 행동 제약으로 어떻게 적용될 수 있는지 탐구합니다.
+      </p>
+    </div>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Agent Role Add-on이란?
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      state-ref Agent Role Add-on은 AI 코딩 에이전트(OpenCode, 커스텀 에이전트, IDE 확장 등)를 위한 복사-붙여넣기 준비된 행동 확장입니다. 프로젝트별 스킬 패키지와 달리, 이 add-on은 에이전트의 시스템 프롬프트에 직접 첨부되어 모든 프로젝트에서 작동합니다.
+    </p>
+
+    <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mb-6">
+      <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
+        <span class="font-medium">주요 차이점:</span> Skills 파일은 프로젝트별 구성입니다. Agent add-on은 프로젝트 컨텍스트에 따라 조건부로 활성화되는 글로벌 에이전트 행동입니다.
+      </p>
+    </div>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      주요 기능
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li><strong>조건부 활성화:</strong> 프로젝트에서 state-ref가 감지된 경우에만 state-ref 패턴을 제안</li>
+      <li><strong>자동 감지:</strong> <code class="text-sm">package.json</code>, <code class="text-sm">node_modules</code>, 기존 import 확인</li>
+      <li><strong>비 state-ref 프로젝트 존중:</strong> state-ref가 설치되지 않은 경우 표준 코딩 관행 사용</li>
+      <li><strong>단일 구성:</strong> 다양한 기술 스택을 가진 여러 프로젝트에서 작동</li>
+      <li><strong>복사-붙여넣기 준비:</strong> 복잡한 설정 없이 에이전트의 시스템 프롬프트에 붙여넣기만 하면 됨</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      이 Add-on을 사용해야 할 때
+    </h2>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      사용해야 할 때:
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>state-ref를 사용하는 프로젝트와 사용하지 않는 프로젝트를 오가며 작업할 때</li>
+      <li>state-ref가 감지되면 자동으로 패턴 가이드를 원할 때</li>
+      <li>팀이 프로젝트별로 선택적으로 state-ref를 채택할 때</li>
+      <li>프로젝트 컨텍스트에 맞게 적응하는 단일 에이전트 구성이 필요할 때</li>
+    </ul>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      사용하지 말아야 할 때:
+    </h3>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>state-ref를 절대 사용하지 않는 프로젝트에서만 작업할 때</li>
+      <li>반응형 패턴을 적용할 시점을 수동으로 제어하길 원할 때</li>
+      <li>에이전트 구성이 글로벌이 아닌 프로젝트별일 때</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      이 Add-on 첨부 방법
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      아래의 행동 제약 블록을 복사하여 AI 에이전트의 시스템 프롬프트 또는 구성에 붙여넣으세요.
+    </p>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      이 블록 복사하기
+    </h3>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+      아래의 전체 add-on 구성을 복사하세요:
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={ADDON_CODE}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      통합 예제
+    </h2>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      OpenCode (.opencode/config.yaml)
+    </h3>
+
+    <CodeBlock
+      language="bash"
+      code={`agent:
+  role: "Your Agent Role"
+  extensions:
+    - type: "state-ref-addon"
+      content: |
+        [여기에 state-ref 제약 블록을 붙여넣으세요]`}
+    />
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
+      커스텀 에이전트 시스템 프롬프트
+    </h3>
+
+    <CodeBlock
+      language="bash"
+      code={`<your-existing-agent-role>
+  <identity>
+    You are a [에이전트 설명]...
+  </identity>
+
+  <capabilities>
+    [에이전트 능력]...
+  </capabilities>
+
+  <!-- 여기에 state-ref 행동 제약 삽입 -->
+  <coding-constraints>
+    [여기에 state-ref 제약 블록을 붙여넣으세요]
+  </coding-constraints>
+
+  <workflow>
+    [에이전트 워크플로우]...
+  </workflow>
+</your-existing-agent-role>`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      작동 방식
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      add-on은 프로젝트 컨텍스트에 따라 행동을 조정하는 조건부 로직을 사용합니다:
+    </p>
+
+    <div class="space-y-6 mb-6">
+      <div class="bg-green-50 dark:bg-green-900/20 p-6 rounded-lg border border-green-200 dark:border-green-800">
+        <h4 class="text-lg font-medium text-green-900 dark:text-green-200 mb-2">
+          state-ref가 설치된 경우
+        </h4>
+        <p class="text-sm text-green-800 dark:text-green-300">
+          에이전트가 state-ref 패턴을 제안하고, 반응형 접근 방식의 이점을 설명하며, 명확성을 위해 세밀한 반응성을 우선시하면서 사용자 선호도를 존중합니다.
+        </p>
+      </div>
+
+      <div class="bg-gray-50 dark:bg-gray-800/20 p-6 rounded-lg border border-gray-200 dark:border-gray-700">
+        <h4 class="text-lg font-medium text-gray-900 dark:text-gray-200 mb-2">
+          state-ref가 설치되지 않은 경우
+        </h4>
+        <p class="text-sm text-gray-700 dark:text-gray-400">
+          에이전트가 프로젝트에 적합한 표준 코딩 관행을 사용하고, state-ref를 언급하지 않으며, 기존 규칙을 존중합니다.
+        </p>
+      </div>
+    </div>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      감지 메커니즘
+    </h3>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+      에이전트는 다음을 통해 state-ref 가용성을 확인합니다:
+    </p>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li><code class="text-sm">package.json</code> 의존성 선언 (가장 신뢰할 수 있음)</li>
+      <li><code class="text-sm">node_modules</code> 디렉토리 존재 (설치 확인)</li>
+      <li>기존 import 문 (사용 확인)</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      전체 문서
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      완전한 add-on 문서는 설치 후 <code class="text-sm">node_modules/state-ref/dist/ai-addons/state-ref-agent-addon.md</code>에서 확인할 수 있습니다.
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      {' '}
+      <a
+        href="https://github.com/superlucky84/state-ref/blob/main/state-ref-agent-addon.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        GitHub 저장소
+      </a>
+      에서도 확인할 수 있습니다.
+    </p>
+
+    <div class="bg-yellow-50 dark:bg-yellow-900/20 p-6 rounded-lg border border-yellow-200 dark:border-yellow-800 mt-6">
+      <p class="text-sm md:text-base text-yellow-900 dark:text-yellow-200 leading-relaxed">
+        <span class="font-medium">중요:</span> 이 add-on은 시스템 프롬프트를 지원하는 에이전트를 위해 설계되었습니다. 프로젝트별 AI 지원(Claude Code의 skills 등)의 경우 <a href="#/ko/ai-agent-skills" class="text-yellow-700 dark:text-yellow-300 hover:underline">AI Agent Skills</a> 파일을 대신 사용하세요.
+      </p>
+    </div>
+  </div>
+);

--- a/stateRefDocs/src/pages/AIAgentSkills.tsx
+++ b/stateRefDocs/src/pages/AIAgentSkills.tsx
@@ -1,0 +1,213 @@
+import { CodeBlock } from '@/components/CodeBlock';
+
+export const AIAgentSkills = () => (
+  <div class="prose prose-lg dark:prose-invert max-w-none">
+    <h1 class="text-3xl md:text-4xl font-semibold text-gray-900 dark:text-white mb-6">
+      AI Agent Skills
+    </h1>
+
+    <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
+      Help AI coding assistants write state-ref-style reactive code automatically
+    </p>
+
+    <div class="bg-purple-50 dark:bg-purple-900/20 p-6 rounded-lg border border-purple-200 dark:border-purple-800 mb-8">
+      <h3 class="text-lg font-medium text-purple-900 dark:text-purple-200 mb-2">
+        Experimental by Design
+      </h3>
+      <p class="text-sm text-purple-800 dark:text-purple-300">
+        This specification explores how state-ref can be applied as a first-class behavioral constraint for AI coding agents.
+      </p>
+    </div>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      What is AI Agent Skills?
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      state-ref includes an AI agent skills package that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write state-ref-style reactive code.
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      When you have this skills package in your project, AI assistants will:
+    </p>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>Use <code class="text-sm">createStore</code> for reactive state management</li>
+      <li>Access values via <code class="text-sm">.value</code> property correctly</li>
+      <li>Use <code class="text-sm">watch(callback)</code> for subscriptions with proper dependency tracking</li>
+      <li>Handle <code class="text-sm">AbortController</code> for cleanup</li>
+      <li>Use framework connectors (<code class="text-sm">connectReact</code>, <code class="text-sm">connectVue</code>, etc.) appropriately</li>
+      <li>Apply <code class="text-sm">createStoreManualSync</code> for Flux-like patterns</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Setup for Claude Code
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      Copy the skills folder to your project's <code class="text-sm">.claude/skills/</code> directory:
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# Unix/macOS/Linux
+mkdir -p .claude/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref/
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path .claude/skills/state-ref
+Copy-Item node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref -Recurse
+
+# Or manually create the directory and copy
+mkdir -p .claude/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref/`}
+    />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      If your tool expects a single file, point it to <code class="text-sm">.claude/skills/state-ref/SKILL.md</code> or link that file to <code class="text-sm">.claude/skills/state-ref.md</code>.
+    </p>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Setup for Codex
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      Copy the Codex skill to your project's <code class="text-sm">$CODEX_HOME/skills/</code> directory (default: <code class="text-sm">~/.codex/skills</code>):
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# Unix/macOS/Linux
+mkdir -p ~/.codex/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* ~/.codex/skills/state-ref/
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/state-ref"
+Copy-Item node_modules/state-ref/dist/skills/state-ref/* $HOME/.codex/skills/state-ref -Recurse`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Recommended: Add CLAUDE.md to Your Project
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      For better reliability, create a <code class="text-sm">CLAUDE.md</code> file in your project root. This ensures AI agents read the state-ref skills package before writing code.
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# Project Instructions for AI Agents
+
+## CRITICAL: state-ref Requirements
+
+**Before writing ANY code, you MUST:**
+
+1. Read \`.claude/skills/state-ref/SKILL.md\` **completely**
+2. Follow the common-mistakes section **strictly**
+3. Use the patterns shown in examples
+
+**Non-negotiable rules:**
+- Always access values via \`.value\` property
+- Track dependencies inside subscription callbacks only
+- Use \`AbortController.signal\` for cleanup
+- In manual-sync mode, use \`updateRef\` and call \`sync()\`
+
+**This is not optional - violating these patterns will break the codebase.**`}
+    />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6 mt-6">
+      Place this file as <code class="text-sm">CLAUDE.md</code> in your project root. Claude Code will automatically read this file at the start of every conversation.
+    </p>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      How It Works
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      Once configured, AI assistants will automatically apply state-ref coding patterns when helping you write code.
+    </p>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      Example: Before Skills File
+    </h3>
+
+    <CodeBlock
+      language="typescript"
+      code={`// AI might suggest manual state management
+let count = 0;
+const listeners: (() => void)[] = [];
+
+function subscribe(callback: () => void) {
+  listeners.push(callback);
+  return () => {
+    const index = listeners.indexOf(callback);
+    if (index > -1) listeners.splice(index, 1);
+  };
+}
+
+function setCount(value: number) {
+  count = value;
+  listeners.forEach(fn => fn());
+}`}
+    />
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      Example: After Skills File
+    </h3>
+
+    <CodeBlock
+      language="typescript"
+      code={`// AI suggests state-ref reactive style
+import { createStore } from 'state-ref';
+
+const watch = createStore({ count: 0 });
+
+// Subscribe to changes
+watch((ref, isFirst) => {
+  console.log('Count:', ref.count.value);
+});
+
+// Update state
+const ref = watch();
+ref.count.value = 10;`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Skills File Location
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      The skills package is located at <code class="text-sm">node_modules/state-ref/dist/skills/state-ref/</code> after installation (includes <code class="text-sm">SKILL.md</code>, <code class="text-sm">examples/</code>, <code class="text-sm">reference/</code>, and <code class="text-sm">constraints/</code>).
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      You can also view it in the{' '}
+      <a
+        href="https://github.com/superlucky84/state-ref/blob/main/skills/state-ref/SKILL.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        GitHub repository
+      </a>.
+    </p>
+
+    <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mt-6">
+      <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
+        <span class="font-medium">Tip:</span> After setting up the skills package, you can ask your AI assistant questions like "refactor this to use state-ref" or "add reactive state management", and it will automatically apply the patterns.
+      </p>
+    </div>
+  </div>
+);

--- a/stateRefDocs/src/pages/AIAgentSkills_ko.tsx
+++ b/stateRefDocs/src/pages/AIAgentSkills_ko.tsx
@@ -1,0 +1,214 @@
+import { CodeBlock } from '@/components/CodeBlock';
+
+export const AIAgentSkillsKo = () => (
+  <div class="prose prose-lg dark:prose-invert max-w-none">
+    <h1 class="text-3xl md:text-4xl font-semibold text-gray-900 dark:text-white mb-6">
+      AI Agent Skills
+    </h1>
+
+    <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
+      AI 코딩 어시스턴트가 state-ref 스타일의 반응형 코드를 자동으로 작성하도록 도와줍니다
+    </p>
+
+    <div class="bg-purple-50 dark:bg-purple-900/20 p-6 rounded-lg border border-purple-200 dark:border-purple-800 mb-8">
+      <h3 class="text-lg font-medium text-purple-900 dark:text-purple-200 mb-2">
+        실험적 기능
+      </h3>
+      <p class="text-sm text-purple-800 dark:text-purple-300">
+        이 스펙은 state-ref가 AI 코딩 에이전트의 일급 행동 제약으로 어떻게 적용될 수 있는지 탐구합니다.
+      </p>
+    </div>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      AI Agent Skills란?
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      state-ref에는 AI 코딩 어시스턴트(Claude Code, GitHub Copilot, Cursor 등)가 자동으로 state-ref 스타일의 반응형 코드를 작성하도록 돕는 AI 에이전트 스킬 패키지가 포함되어 있습니다.
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      프로젝트에 이 스킬 패키지가 있으면, AI 어시스턴트는 다음을 수행합니다:
+    </p>
+
+    <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>반응형 상태 관리를 위해 <code class="text-sm">createStore</code> 사용</li>
+      <li><code class="text-sm">.value</code> 속성을 통해 값에 올바르게 접근</li>
+      <li>적절한 의존성 추적과 함께 <code class="text-sm">watch(callback)</code>을 사용한 구독</li>
+      <li>정리를 위한 <code class="text-sm">AbortController</code> 처리</li>
+      <li>프레임워크 커넥터(<code class="text-sm">connectReact</code>, <code class="text-sm">connectVue</code> 등)를 적절히 사용</li>
+      <li>Flux 패턴을 위한 <code class="text-sm">createStoreManualSync</code> 적용</li>
+    </ul>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Claude Code 설정
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      skills 폴더를 프로젝트의 <code class="text-sm">.claude/skills/</code> 디렉토리에 복사하세요:
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# Unix/macOS/Linux
+mkdir -p .claude/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref/
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path .claude/skills/state-ref
+Copy-Item node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref -Recurse
+
+# 또는 수동으로 디렉토리를 만들고 복사
+mkdir -p .claude/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* .claude/skills/state-ref/`}
+    />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      도구가 단일 파일을 기대하는 경우, <code class="text-sm">.claude/skills/state-ref/SKILL.md</code>를 가리키거나 해당 파일을 <code class="text-sm">.claude/skills/state-ref.md</code>로 링크하세요.
+    </p>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Codex 설정
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      Codex 스킬을 프로젝트의 <code class="text-sm">$CODEX_HOME/skills/</code> 디렉토리(기본값: <code class="text-sm">~/.codex/skills</code>)에 복사하세요:
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# Unix/macOS/Linux
+mkdir -p ~/.codex/skills/state-ref
+cp -R node_modules/state-ref/dist/skills/state-ref/* ~/.codex/skills/state-ref/
+
+# Windows (PowerShell)
+New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/state-ref"
+Copy-Item node_modules/state-ref/dist/skills/state-ref/* $HOME/.codex/skills/state-ref -Recurse`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      권장: 프로젝트에 CLAUDE.md 추가
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      더 나은 신뢰성을 위해 프로젝트 루트에 <code class="text-sm">CLAUDE.md</code> 파일을 생성하세요. 이렇게 하면 AI 에이전트가 코드를 작성하기 전에 state-ref 스킬 패키지를 읽게 됩니다.
+    </p>
+
+    <CodeBlock
+      language="bash"
+      code={`# AI 에이전트를 위한 프로젝트 지침
+
+## 중요: state-ref 요구사항
+
+**코드를 작성하기 전에 반드시:**
+
+1. \`.claude/skills/state-ref/SKILL.md\`를 **완전히** 읽으세요
+2. common-mistakes 섹션을 **엄격히** 따르세요
+3. 예제에 표시된 패턴을 사용하세요
+
+**협상 불가 규칙:**
+- 항상 \`.value\` 속성을 통해 값에 접근
+- 구독 콜백 내부에서만 의존성 추적
+- 정리를 위해 \`AbortController.signal\` 사용
+- manual-sync 모드에서는 \`updateRef\`를 사용하고 \`sync()\` 호출
+
+**이것은 선택사항이 아닙니다 - 이 패턴을 위반하면 코드베이스가 손상됩니다.**`}
+    />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6 mt-6">
+      이 파일을 프로젝트 루트에 <code class="text-sm">CLAUDE.md</code>로 배치하세요. Claude Code는 모든 대화 시작 시 자동으로 이 파일을 읽습니다.
+    </p>
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      작동 방식
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      설정이 완료되면, AI 어시스턴트는 코드 작성을 도울 때 자동으로 state-ref 코딩 패턴을 적용합니다.
+    </p>
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      예제: Skills 파일 적용 전
+    </h3>
+
+    <CodeBlock
+      language="typescript"
+      code={`// AI가 수동 상태 관리를 제안할 수 있음
+let count = 0;
+const listeners: (() => void)[] = [];
+
+function subscribe(callback: () => void) {
+  listeners.push(callback);
+  return () => {
+    const index = listeners.indexOf(callback);
+    if (index > -1) listeners.splice(index, 1);
+  };
+}
+
+function setCount(value: number) {
+  count = value;
+  listeners.forEach(fn => fn());
+}`}
+    />
+
+    <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-8">
+      예제: Skills 파일 적용 후
+    </h3>
+
+    <CodeBlock
+      language="typescript"
+      code={`// AI가 state-ref 반응형 스타일을 제안
+import { createStore } from 'state-ref';
+
+const watch = createStore({ count: 0 });
+
+// 변경 사항 구독
+watch((ref, isFirst) => {
+  console.log('Count:', ref.count.value);
+});
+
+// 상태 업데이트
+const ref = watch();
+ref.count.value = 10;`}
+    />
+
+    <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
+
+    <h2 class="text-2xl md:text-3xl font-medium text-gray-900 dark:text-white mb-4">
+      Skills 파일 위치
+    </h2>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      스킬 패키지는 설치 후 <code class="text-sm">node_modules/state-ref/dist/skills/state-ref/</code>에 위치합니다 (<code class="text-sm">SKILL.md</code>, <code class="text-sm">examples/</code>, <code class="text-sm">reference/</code>, <code class="text-sm">constraints/</code> 포함).
+    </p>
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      {' '}
+      <a
+        href="https://github.com/superlucky84/state-ref/blob/main/skills/state-ref/SKILL.md"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        GitHub 저장소
+      </a>
+      에서도 확인할 수 있습니다.
+    </p>
+
+    <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mt-6">
+      <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
+        <span class="font-medium">팁:</span> 스킬 패키지를 설정한 후, AI 어시스턴트에게 "state-ref를 사용하여 리팩토링해줘" 또는 "반응형 상태 관리를 추가해줘"와 같은 질문을 하면 자동으로 패턴이 적용됩니다.
+      </p>
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Summary

  - Add AI Agent Skills package for AI coding assistants (Claude Code, Copilot, Cursor, etc.)
  - Add AI Agent Role Add-on for system prompt integration
  - Add documentation pages for both features in stateRefDocs

  ## Changes

  ### Skills Package (`skills/state-ref/`)
  - `SKILL.md` - Main skill document with core rules and examples
  - `constraints/` - Core rules, common mistakes, troubleshooting guides
  - `reference/` - Watch function, store creation, framework connectors
  - `examples/` - Quick examples for common patterns

  ### Agent Role Add-on (`state-ref-agent-addon.md`)
  - Copy-paste ready behavior extension for AI agents
  - Conditional activation based on state-ref installation
  - Coding guidelines for reactive state management

  ### Build Integration
  - `scripts/copy-skills.mjs` - Build script to copy skills with version injection
  - Updated `package.json` build script to include skills copy
  - Updated `packages/state-ref/package.json` files to include `dist/skills` and `dist/ai-addons`

  ### Documentation Site (`stateRefDocs/`)
  - Added AI Agent Skills page (EN/KO)
  - Added AI Agent Role Add-on page (EN/KO)
  - Updated Sidebar with new menu items
  - Updated Layout with new routes